### PR TITLE
Avoid using a metric_query block where one is not strictly necessary

### DIFF
--- a/aws_ec2_alarms.tf
+++ b/aws_ec2_alarms.tf
@@ -8,54 +8,42 @@
 resource "aws_cloudwatch_metric_alarm" "system_status_check" {
   for_each = toset(var.instance_ids)
 
-  alarm_actions             = var.alarm_actions
-  alarm_description         = "Monitor EC2 system status check"
-  alarm_name                = "ec2_system_status_check_${each.value}"
-  comparison_operator       = "GreaterThanThreshold"
+  alarm_actions       = var.alarm_actions
+  alarm_description   = "Monitor EC2 system status check"
+  alarm_name          = "ec2_system_status_check_${each.value}"
+  comparison_operator = "GreaterThanThreshold"
+  dimensions = {
+    InstanceId = each.value
+  }
   evaluation_periods        = 1
   insufficient_data_actions = var.insufficient_data_actions
-  metric_query {
-    id = "system_status_check"
-    metric {
-      dimensions = {
-        InstanceId = each.value
-      }
-      metric_name = "StatusCheckFailed_System"
-      namespace   = "AWS/EC2"
-      period      = 60
-      stat        = "Maximum"
-    }
-    return_data = true
-  }
-  ok_actions = var.ok_actions
-  threshold  = 0
+  metric_name               = "StatusCheckFailed_System"
+  namespace                 = "AWS/EC2"
+  ok_actions                = var.ok_actions
+  period                    = 60
+  statistic                 = "Maximum"
+  threshold                 = 0
 }
 
 # Alarm if an instance status check ever fails.
 resource "aws_cloudwatch_metric_alarm" "instance_status_check" {
   for_each = toset(var.instance_ids)
 
-  alarm_actions             = var.alarm_actions
-  alarm_description         = "Monitor EC2 instance status check"
-  alarm_name                = "ec2_instance_status_check_${each.value}"
-  comparison_operator       = "GreaterThanThreshold"
+  alarm_actions       = var.alarm_actions
+  alarm_description   = "Monitor EC2 instance status check"
+  alarm_name          = "ec2_instance_status_check_${each.value}"
+  comparison_operator = "GreaterThanThreshold"
+  dimensions = {
+    InstanceId = each.value
+  }
   evaluation_periods        = 1
   insufficient_data_actions = var.insufficient_data_actions
-  metric_query {
-    id = "instance_status_check"
-    metric {
-      dimensions = {
-        InstanceId = each.value
-      }
-      metric_name = "StatusCheckFailed_Instance"
-      namespace   = "AWS/EC2"
-      period      = 60
-      stat        = "Maximum"
-    }
-    return_data = true
-  }
-  ok_actions = var.ok_actions
-  threshold  = 0
+  metric_name               = "StatusCheckFailed_Instance"
+  namespace                 = "AWS/EC2"
+  ok_actions                = var.ok_actions
+  period                    = 60
+  statistic                 = "Maximum"
+  threshold                 = 0
 }
 
 # Alarm if an IMDSv1 request ever succeeds.
@@ -65,53 +53,41 @@ resource "aws_cloudwatch_metric_alarm" "instance_status_check" {
 resource "aws_cloudwatch_metric_alarm" "imdsv1_request" {
   for_each = toset(var.instance_ids)
 
-  alarm_actions             = var.alarm_actions
-  alarm_description         = "Monitor EC2 instance MetadataNoToken metric"
-  alarm_name                = "ec2_metadata_no_token_${each.value}"
-  comparison_operator       = "GreaterThanThreshold"
+  alarm_actions       = var.alarm_actions
+  alarm_description   = "Monitor EC2 instance MetadataNoToken metric"
+  alarm_name          = "ec2_metadata_no_token_${each.value}"
+  comparison_operator = "GreaterThanThreshold"
+  dimensions = {
+    InstanceId = each.value
+  }
   evaluation_periods        = 1
   insufficient_data_actions = var.insufficient_data_actions
-  metric_query {
-    id = "imdsv1_request"
-    metric {
-      dimensions = {
-        InstanceId = each.value
-      }
-      metric_name = "MetadataNoToken"
-      namespace   = "AWS/EC2"
-      period      = 300
-      stat        = "Maximum"
-    }
-    return_data = true
-  }
-  ok_actions = var.ok_actions
-  threshold  = 0
+  metric_name               = "MetadataNoToken"
+  namespace                 = "AWS/EC2"
+  period                    = 300
+  statistic                 = "Maximum"
+  ok_actions                = var.ok_actions
+  threshold                 = 0
 }
 
 # Alarm for CPU utilization
 resource "aws_cloudwatch_metric_alarm" "cpu_utilization" {
   for_each = var.cpu_utilization_alarm_parameters.create_alarm ? toset(var.instance_ids) : toset([])
 
-  alarm_actions             = var.alarm_actions
-  alarm_description         = "Monitor EC2 instance CPU utilization"
-  alarm_name                = "ec2_cpu_utilization_${each.value}"
-  comparison_operator       = "GreaterThanThreshold"
-  datapoints_to_alarm       = var.cpu_utilization_alarm_parameters.datapoints_to_alarm
+  alarm_actions       = var.alarm_actions
+  alarm_description   = "Monitor EC2 instance CPU utilization"
+  alarm_name          = "ec2_cpu_utilization_${each.value}"
+  comparison_operator = "GreaterThanThreshold"
+  datapoints_to_alarm = var.cpu_utilization_alarm_parameters.datapoints_to_alarm
+  dimensions = {
+    InstanceId = each.value
+  }
   evaluation_periods        = var.cpu_utilization_alarm_parameters.evaluation_periods
   insufficient_data_actions = var.insufficient_data_actions
-  metric_query {
-    id = "cpu_utilization"
-    metric {
-      dimensions = {
-        InstanceId = each.value
-      }
-      metric_name = "CPUUtilization"
-      namespace   = "AWS/EC2"
-      period      = var.cpu_utilization_alarm_parameters.period
-      stat        = var.cpu_utilization_alarm_parameters.statistic
-    }
-    return_data = true
-  }
-  ok_actions = var.ok_actions
-  threshold  = var.cpu_utilization_alarm_parameters.threshold
+  metric_name               = "CPUUtilization"
+  namespace                 = "AWS/EC2"
+  period                    = var.cpu_utilization_alarm_parameters.period
+  statistic                 = var.cpu_utilization_alarm_parameters.statistic
+  ok_actions                = var.ok_actions
+  threshold                 = var.cpu_utilization_alarm_parameters.threshold
 }

--- a/cwagent_alarms.tf
+++ b/cwagent_alarms.tf
@@ -9,56 +9,44 @@
 resource "aws_cloudwatch_metric_alarm" "memory_utilization" {
   for_each = var.memory_utilization_alarm_parameters.create_alarm ? toset(var.instance_ids) : toset([])
 
-  alarm_actions             = var.alarm_actions
-  alarm_description         = "Monitor EC2 instance memory utilization"
-  alarm_name                = "ec2_memory_utilization_${each.value}"
-  comparison_operator       = "GreaterThanThreshold"
-  datapoints_to_alarm       = var.memory_utilization_alarm_parameters.datapoints_to_alarm
+  alarm_actions       = var.alarm_actions
+  alarm_description   = "Monitor EC2 instance memory utilization"
+  alarm_name          = "ec2_memory_utilization_${each.value}"
+  comparison_operator = "GreaterThanThreshold"
+  datapoints_to_alarm = var.memory_utilization_alarm_parameters.datapoints_to_alarm
+  dimensions = {
+    InstanceId = each.value
+  }
   evaluation_periods        = var.memory_utilization_alarm_parameters.evaluation_periods
   insufficient_data_actions = var.insufficient_data_actions
-  metric_query {
-    id = "memory_utilization"
-    metric {
-      dimensions = {
-        InstanceId = each.value
-      }
-      metric_name = "mem_used_percent"
-      namespace   = "CWAgent"
-      period      = var.memory_utilization_alarm_parameters.period
-      stat        = var.memory_utilization_alarm_parameters.statistic
-    }
-    return_data = true
-  }
-  ok_actions = var.ok_actions
-  threshold  = var.memory_utilization_alarm_parameters.threshold
+  metric_name               = "mem_used_percent"
+  namespace                 = "CWAgent"
+  period                    = var.memory_utilization_alarm_parameters.period
+  statistic                 = var.memory_utilization_alarm_parameters.statistic
+  ok_actions                = var.ok_actions
+  threshold                 = var.memory_utilization_alarm_parameters.threshold
 }
 
 # Alarm for disk utilization.
 resource "aws_cloudwatch_metric_alarm" "disk_utilization" {
   for_each = var.disk_utilization_alarm_parameters.create_alarm ? toset(var.instance_ids) : toset([])
 
-  alarm_actions             = var.alarm_actions
-  alarm_description         = "Monitor EC2 instance disk utilization"
-  alarm_name                = "ec2_disk_utilization_${each.key}"
-  comparison_operator       = "GreaterThanThreshold"
-  datapoints_to_alarm       = var.disk_utilization_alarm_parameters.datapoints_to_alarm
+  alarm_actions       = var.alarm_actions
+  alarm_description   = "Monitor EC2 instance disk utilization"
+  alarm_name          = "ec2_disk_utilization_${each.key}"
+  comparison_operator = "GreaterThanThreshold"
+  datapoints_to_alarm = var.disk_utilization_alarm_parameters.datapoints_to_alarm
+  dimensions = {
+    InstanceId = each.value
+  }
   evaluation_periods        = var.disk_utilization_alarm_parameters.evaluation_periods
   insufficient_data_actions = var.insufficient_data_actions
-  metric_query {
-    id = "disk_utilization"
-    metric {
-      dimensions = {
-        InstanceId = each.value
-      }
-      metric_name = "disk_used_percent"
-      namespace   = "CWAgent"
-      period      = var.disk_utilization_alarm_parameters.period
-      stat        = var.disk_utilization_alarm_parameters.statistic
-    }
-    return_data = true
-  }
-  ok_actions = var.ok_actions
-  threshold  = var.disk_utilization_alarm_parameters.threshold
+  metric_name               = "disk_used_percent"
+  namespace                 = "CWAgent"
+  period                    = var.disk_utilization_alarm_parameters.period
+  statistic                 = var.disk_utilization_alarm_parameters.statistic
+  ok_actions                = var.ok_actions
+  threshold                 = var.disk_utilization_alarm_parameters.threshold
 }
 
 # Alarm each time any packets are queued and/or dropped because the


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the code to avoid using a `metric_query` block where one is not strictly necessary.

## 💭 Motivation and context ##

I unsuccessfully attempted to apply the changes from cisagov/cool-sharedservices-freeipa#54 to our production COOL environment last night.  The failure turned out to be because [Route53 health checks cannot currently be created from CloudWatch metric alarms that use a `metric_query` block](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/health-checks-creating-values.html#health-checks-creating-values-cloudwatch).  We want our alarms to be usable for that purpose where possible, so it makes sense to avoid using such a block unless it is strictly necessary.

## 🧪 Testing ##

All automated testing passes, and I have successfully deployed these changes to our COOL staging and production environments.

Interestingly, this problem did not surface when I applied the changes from #5 and cisagov/cool-sharedservices-freeipa#54 to our staging COOL environment.  That is because I had originally created the alarms without the `metric_query` blocks, applied that code, and then changed the alarms to use the `metric_query` blocks and (apparently) never did a full reapply.  Mea culpa.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.