### PR TITLE
Modify status check alarms to avoid transient failures

### DIFF
--- a/aws_ec2_alarms.tf
+++ b/aws_ec2_alarms.tf
@@ -4,7 +4,8 @@
 # AWS EC2 managed service (i.e., from the AWS/EC2 metric namespace).
 # ------------------------------------------------------------------------------
 
-# Alarm if a system status check ever fails.
+# Alarm if a system status check ever fails for at least five minutes
+# straight.
 resource "aws_cloudwatch_metric_alarm" "system_status_check" {
   for_each = toset(var.instance_ids)
 
@@ -15,17 +16,18 @@ resource "aws_cloudwatch_metric_alarm" "system_status_check" {
   dimensions = {
     InstanceId = each.value
   }
-  evaluation_periods        = 1
+  evaluation_periods        = 5
   insufficient_data_actions = var.insufficient_data_actions
   metric_name               = "StatusCheckFailed_System"
   namespace                 = "AWS/EC2"
   ok_actions                = var.ok_actions
   period                    = 60
   statistic                 = "Maximum"
-  threshold                 = 0
+  threshold                 = 5
 }
 
-# Alarm if an instance status check ever fails.
+# Alarm if an instance status check ever fails for at least five
+# minutes straight.
 resource "aws_cloudwatch_metric_alarm" "instance_status_check" {
   for_each = toset(var.instance_ids)
 
@@ -36,14 +38,14 @@ resource "aws_cloudwatch_metric_alarm" "instance_status_check" {
   dimensions = {
     InstanceId = each.value
   }
-  evaluation_periods        = 1
+  evaluation_periods        = 5
   insufficient_data_actions = var.insufficient_data_actions
   metric_name               = "StatusCheckFailed_Instance"
   namespace                 = "AWS/EC2"
   ok_actions                = var.ok_actions
   period                    = 60
   statistic                 = "Maximum"
-  threshold                 = 0
+  threshold                 = 5
 }
 
 # Alarm if an IMDSv1 request ever succeeds.


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the status check alarms to avoid transient failures.

## 💭 Motivation and context ##

I have noticed that there are some "transient" system check alarms that happen occasionally.  An instance will signal a status check failure, which reverts to an OK state one minute later.  The resulting notifications can cause a lot of noise.  Alarming only on five straight minutes of failure should result in these transient failures no longer causing alarms.

## 🧪 Testing ##

All automated testing passes.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.